### PR TITLE
Error in epr config

### DIFF
--- a/server/internal/types/config/webrtc.go
+++ b/server/internal/types/config/webrtc.go
@@ -142,13 +142,13 @@ func (s *WebRTC) Set() {
 	max := uint16(59100)
 	epr := viper.GetString("epr")
 	ports := strings.SplitN(epr, "-", -1)
-	if len(ports[0]) > 1 {
-		start, err := strconv.ParseUint(ports[0], 16, 16)
+	if len(ports) > 1 {
+		start, err := strconv.ParseUint(ports[0], 10, 16)
 		if err == nil {
 			min = uint16(start)
 		}
 
-		end, err := strconv.ParseUint(ports[1], 16, 16)
+		end, err := strconv.ParseUint(ports[1], 10, 16)
 		if err == nil {
 			max = uint16(end)
 		}


### PR DESCRIPTION
Condition was incorrect, i suppose it shoud check if there are two elemnts in array, not if first element is at least 2 characters long.

Also, i suppose the epr config values are supplied in base**10**. Here it expects base**16**. Even though in docs is not much about it written, there is exaple with `59000-59100` values. So it must be base**10**.

Really great project, took me hours to get ports changed and then I found this!