### PR TITLE
Change the login page to use "Display Name" instead of "Username"

### DIFF
--- a/client/src/components/connect.vue
+++ b/client/src/components/connect.vue
@@ -7,7 +7,7 @@
       </div>
       <form class="message" v-if="!connecting" @submit.stop.prevent="connect">
         <span>Please Login</span>
-        <input type="text" placeholder="Username" v-model="username" />
+        <input type="text" placeholder="Display Name" v-model="username" />
         <input type="password" placeholder="Password" v-model="password" />
         <button type="submit" @click.stop.prevent="login">
           Connect


### PR DESCRIPTION
## Purpose

This is to make the UI a little more intuitive to new users. At the moment, the usage of the word "username" implies that there are static accounts that persist between sessions. By using "display name" instead, it is a little more apparent that "display name" is just what your name will be to other users.

# Testing Performed

Uh, I couldn't find any info on how to test this change, but my belief is that this is the correct place to change the page. If a maintainer/someone familiar with how to test this project could verify that this works, I would be really appreciative. I can also test it, if some info is shared to me on how - I'd close the PR and open a new one after testing.