### PR TITLE
Docs updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ COPY server/bin/neko /usr/bin/neko
 #
 # neko env
 ENV NEKO_PASSWORD=neko
-ENV NEKO_ADMIN=admin
+ENV NEKO_PASSWORD_ADMIN=admin
 ENV NEKO_BIND=:8080
 
 #

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,9 +2,9 @@
 
 ## Docker Basic Configuration
 ```
-NEKO_PASSWORD=neko      // Password
-NEKO_ADMIN=neko         // Admin Password
-NEKO_BIND=0.0.0.0:8080  // Bind
-NEKO_KEY=               // (SSL) Key, needed for clipboard sync
-NEKO_CERT=              // (SSL) Cert, needed for clipboard sync
+NEKO_PASSWORD=neko        // Password
+NEKO_PASSWORD_ADMIN=admin // Admin Password
+NEKO_BIND=0.0.0.0:8080    // Bind
+NEKO_KEY=                 // (SSL) Key, needed for clipboard sync
+NEKO_CERT=                // (SSL) Cert, needed for clipboard sync
 ```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -3,13 +3,13 @@
 ## Running:
 ### Chromium container:
 ```
-sudo docker run -p 80:8080 -p 59000-59100:59000-59100/udp -e NEKO_PASSWORD='secret' -e NEKO_ADMIN='secret' --cap-add SYS_ADMIN --shm-size=1gb nurdism/neko:chromium
+sudo docker run -p 80:8080 -p 59000-59100:59000-59100/udp -e NEKO_PASSWORD='secret' -e NEKO_PASSWORD_ADMIN='secret' --cap-add SYS_ADMIN --shm-size=1gb nurdism/neko:chromium
 ```
 *Note:* `--cap-add SYS_ADMIN` & `--shm-size=1gb` is required for chromium to run properly
 
 ----
 ### Firefox container:
 ```
-sudo docker run -p 8080:8080 -p 59000-59100:59000-59100/udp -e NEKO_PASSWORD='secret' -e NEKO_ADMIN='secret' --shm-size=1gb nurdism/neko:firefox 
+sudo docker run -p 8080:8080 -p 59000-59100:59000-59100/udp -e NEKO_PASSWORD='secret' -e NEKO_PASSWORD_ADMIN='secret' --shm-size=1gb nurdism/neko:firefox 
 ```
 *Note:* `--shm-size=1gb` is required for firefox, tabs will crash otherwise

--- a/docs/server.md
+++ b/docs/server.md
@@ -24,7 +24,7 @@ Server for n.eko, as of right now this will *only* work on Linux systems, only t
 --pcmu                        // (bool) use PCMU audio codec
 --pcma                        // (bool) use PCMA audio codec
 --password "neko"             // (string) password for connecting to stream
---admin "admin"               // (string) admin password for connecting to stream
+--password_admin "admin"      // (string) admin password for connecting to stream
 ```
 
 Config can be set via environment variables with the prefix `NEKO_` (I.E. NEKO_BIND="127.0.0.1:8080")

--- a/docs/server.md
+++ b/docs/server.md
@@ -13,7 +13,7 @@ Server for n.eko, as of right now this will *only* work on Linux systems, only t
 --static "./www"              // (string) path to neko client files to serve
 --device "auto_null.monitor"  // (string) audio device to capture
 --display ":99.0"             // (string) XDisplay to capture
---aduio ""                    // (string) audio codec parameters to use for streaming (unused)
+--audio ""                    // (string) audio codec parameters to use for streaming (unused)
 --video ""                    // (string) video codec parameters to use for streaming (unused)
 --epr "59000-59100"           // (string) limits the pool of ephemeral ports that ICE UDP connections can allocate from
 --vp8                         // (bool) use VP8 video codec

--- a/docs/server.md
+++ b/docs/server.md
@@ -4,27 +4,31 @@ Server for n.eko, as of right now this will *only* work on Linux systems, only t
 ## Configuration
 ------
 ```
---debug                       // (bool) enable debug mode
---logs                        // (bool) save logs to file
---config ""                   // (string) configuration file path
---bind "127.0.0.1:8080"       // (string) address/port/socket to serve neko
---cert ""                     // (string) path to the SSL cert used to secure the neko server
---key ""                      // (string) path to the SSL key used to secure the neko server
---static "./www"              // (string) path to neko client files to serve
---device "auto_null.monitor"  // (string) audio device to capture
---display ":99.0"             // (string) XDisplay to capture
---audio ""                    // (string) audio codec parameters to use for streaming (unused)
---video ""                    // (string) video codec parameters to use for streaming (unused)
---epr "59000-59100"           // (string) limits the pool of ephemeral ports that ICE UDP connections can allocate from
---vp8                         // (bool) use VP8 video codec
---vp9                         // (bool) use VP9 video codec
---h264                        // (bool) use H264 video codec
---opus                        // (bool) use Opus audio codec
---g722                        // (bool) use G722 audio codec
---pcmu                        // (bool) use PCMU audio codec
---pcma                        // (bool) use PCMA audio codec
---password "neko"             // (string) password for connecting to stream
---password_admin "admin"      // (string) admin password for connecting to stream
+--debug                                     // (bool) enable debug mode
+--logs                                      // (bool) save logs to file
+--config ""                                 // (string) configuration file path
+--bind "127.0.0.1:8080"                     // (string) address/port/socket to serve neko
+--cert ""                                   // (string) path to the SSL cert used to secure the neko server
+--key ""                                    // (string) path to the SSL key used to secure the neko server
+--static "./www"                            // (string) path to neko client files to serve
+--device "auto_null.monitor"                // (string) audio device to capture
+--display ":99.0"                           // (string) XDisplay to capture
+--audio ""                                  // (string) audio codec parameters to use for streaming (unused)
+--video ""                                  // (string) video codec parameters to use for streaming (unused)
+--screen "1280x720@30"                      // (string) default screen resolution and framerate
+--epr "59000-59100"                         // (string) limits the pool of ephemeral ports that ICE UDP connections can allocate from
+--vp8                                       // (bool) use VP8 video codec
+--vp9                                       // (bool) use VP9 video codec
+--h264                                      // (bool) use H264 video codec
+--opus                                      // (bool) use Opus audio codec
+--g722                                      // (bool) use G722 audio codec
+--pcmu                                      // (bool) use PCMU audio codec
+--pcma                                      // (bool) use PCMA audio codec
+--nat1to1                                   // ([]string) sets a list of external IP addresses of 1:1 (D)NAT and a candidate type for which the external IP address is used
+--icelite                                   // (bool) configures whether or not the ice agent should be a lite agent
+--iceserver "stun:stun.l.google.com:19302"  // ([]string) describes a single STUN and TURN server that can be used by the ICEAgent to establish a connection with a peer
+--password "neko"                           // (string) password for connecting to stream
+--password_admin "admin"                    // (string) admin password for connecting to stream
 ```
 
 Config can be set via environment variables with the prefix `NEKO_` (I.E. NEKO_BIND="127.0.0.1:8080")


### PR DESCRIPTION
`NEKO_ADMIN` was changed to `NEKO_PASSWORD_ADMIN` but not in docs (and in Dockerfile as well). 

Minor typo in docs fixed.

Some configs were not in docs, and I personally found `nat1to1` useful. I discovered it after i looked into code. It should be in DOCS.