### PR TITLE
RTCIceServer frontend bug fix

### DIFF
--- a/client/src/neko/base.ts
+++ b/client/src/neko/base.ts
@@ -172,11 +172,12 @@ export abstract class BaseClient extends EventEmitter<BaseEvents> {
       return
     }
 
-    this._peer = new RTCPeerConnection()
-    if (lite !== true) {
+    if (lite) {
       this._peer = new RTCPeerConnection({
         iceServers: [{ urls: servers }],
       })
+    } else {
+      this._peer = new RTCPeerConnection()
     }
 
     this._peer.onconnectionstatechange = event => {


### PR DESCRIPTION
This bug caused following error:
![image](https://user-images.githubusercontent.com/7534274/78565058-a5d7f600-781d-11ea-843a-3c2eab9aaae1.png)

I'm assuming, `servers` should be added only if `lite` is active. Otherwise they are `undefinded`. So likely it's just typo, it should have been `lite === true` instead of `lite !== true`. But no point of createing double `new RTCPeerConnection()` anyhow. It breaks current development stack.