### PR TITLE
Improved i18n

### DIFF
--- a/client/src/components/chat.vue
+++ b/client/src/components/chat.vue
@@ -35,7 +35,7 @@
     <div v-if="!muted" class="chat-send">
       <div class="accent" />
       <div class="text-container">
-        <textarea ref="input" placeholder="Send a message" @keydown="onKeyDown" v-model="content" />
+        <textarea ref="input" :placeholder="$t('send_a_message')" @keydown="onKeyDown" v-model="content" />
         <neko-emoji v-if="emoji" @picked="onEmojiPicked" @done="emoji = false" />
         <i class="emoji-menu fas fa-laugh" @click.stop.prevent="onEmoji"></i>
       </div>

--- a/client/src/components/context.vue
+++ b/client/src/components/context.vue
@@ -165,11 +165,12 @@
 
     kick(member: Member) {
       this.$swal({
-        title: `Kick ${member.displayname}?`,
-        text: `Are you sure you want to kick ${member.displayname}?`,
+        title: this.$t('context.confirm.kick_title', { name: member.displayname }),
+        text: this.$t('context.confirm.kick_text', { name: member.displayname }),
         icon: 'warning',
         showCancelButton: true,
-        confirmButtonText: 'Yes',
+        confirmButtonText: this.$t('context.confirm.button_yes'),
+        cancelButtonText: this.$t('context.confirm.button_cancel'),
       }).then(({ value }) => {
         if (value) {
           this.$accessor.user.kick(member)
@@ -179,11 +180,12 @@
 
     ban(member: Member) {
       this.$swal({
-        title: `Ban ${member.displayname}?`,
-        text: `Are you sure you want to ban ${member.displayname}? You will need to restart the server to undo this.`,
+        title: this.$t('context.confirm.ban_title', { name: member.displayname }),
+        text: this.$t('context.confirm.ban_text', { name: member.displayname }),
         icon: 'warning',
         showCancelButton: true,
-        confirmButtonText: 'Yes',
+        confirmButtonText: this.$t('context.confirm.button_yes'),
+        cancelButtonText: this.$t('context.confirm.button_cancel'),
       }).then(({ value }) => {
         if (value) {
           this.$accessor.user.ban(member)
@@ -193,11 +195,12 @@
 
     mute(member: Member) {
       this.$swal({
-        title: `Mute ${member.displayname}?`,
-        text: `Are you sure you want to mute ${member.displayname}?`,
+        title: this.$t('context.confirm.mute_title', { name: member.displayname }),
+        text: this.$t('context.confirm.mute_text', { name: member.displayname }),
         icon: 'warning',
         showCancelButton: true,
-        confirmButtonText: 'Yes',
+        confirmButtonText: this.$t('context.confirm.button_yes'),
+        cancelButtonText: this.$t('context.confirm.button_cancel'),
       }).then(({ value }) => {
         if (value) {
           this.$accessor.user.mute(member)
@@ -207,11 +210,12 @@
 
     unmute(member: Member) {
       this.$swal({
-        title: `Unmute ${member.displayname}?`,
-        text: `Are you sure you want to unmute ${member.displayname}?`,
+        title: this.$t('context.confirm.unmute_title', { name: member.displayname }),
+        text: this.$t('context.confirm.unmute_text', { name: member.displayname }),
         icon: 'warning',
         showCancelButton: true,
-        confirmButtonText: 'Yes',
+        confirmButtonText: this.$t('context.confirm.button_yes'),
+        cancelButtonText: this.$t('context.confirm.button_cancel'),
       }).then(({ value }) => {
         if (value) {
           this.$accessor.user.unmute(member)

--- a/client/src/components/context.vue
+++ b/client/src/components/context.vue
@@ -165,12 +165,12 @@
 
     kick(member: Member) {
       this.$swal({
-        title: this.$t('context.confirm.kick_title', { name: member.displayname }),
-        text: this.$t('context.confirm.kick_text', { name: member.displayname }),
+        title: this.$t('context.confirm.kick_title', { name: member.displayname }) as string,
+        text: this.$t('context.confirm.kick_text', { name: member.displayname }) as string,
         icon: 'warning',
         showCancelButton: true,
-        confirmButtonText: this.$t('context.confirm.button_yes'),
-        cancelButtonText: this.$t('context.confirm.button_cancel'),
+        confirmButtonText: this.$t('context.confirm.button_yes') as string,
+        cancelButtonText: this.$t('context.confirm.button_cancel') as string,
       }).then(({ value }) => {
         if (value) {
           this.$accessor.user.kick(member)
@@ -180,12 +180,12 @@
 
     ban(member: Member) {
       this.$swal({
-        title: this.$t('context.confirm.ban_title', { name: member.displayname }),
-        text: this.$t('context.confirm.ban_text', { name: member.displayname }),
+        title: this.$t('context.confirm.ban_title', { name: member.displayname }) as string,
+        text: this.$t('context.confirm.ban_text', { name: member.displayname }) as string,
         icon: 'warning',
         showCancelButton: true,
-        confirmButtonText: this.$t('context.confirm.button_yes'),
-        cancelButtonText: this.$t('context.confirm.button_cancel'),
+        confirmButtonText: this.$t('context.confirm.button_yes') as string,
+        cancelButtonText: this.$t('context.confirm.button_cancel') as string,
       }).then(({ value }) => {
         if (value) {
           this.$accessor.user.ban(member)
@@ -195,12 +195,12 @@
 
     mute(member: Member) {
       this.$swal({
-        title: this.$t('context.confirm.mute_title', { name: member.displayname }),
-        text: this.$t('context.confirm.mute_text', { name: member.displayname }),
+        title: this.$t('context.confirm.mute_title', { name: member.displayname }) as string,
+        text: this.$t('context.confirm.mute_text', { name: member.displayname }) as string,
         icon: 'warning',
         showCancelButton: true,
-        confirmButtonText: this.$t('context.confirm.button_yes'),
-        cancelButtonText: this.$t('context.confirm.button_cancel'),
+        confirmButtonText: this.$t('context.confirm.button_yes') as string,
+        cancelButtonText: this.$t('context.confirm.button_cancel') as string,
       }).then(({ value }) => {
         if (value) {
           this.$accessor.user.mute(member)
@@ -210,12 +210,12 @@
 
     unmute(member: Member) {
       this.$swal({
-        title: this.$t('context.confirm.unmute_title', { name: member.displayname }),
-        text: this.$t('context.confirm.unmute_text', { name: member.displayname }),
+        title: this.$t('context.confirm.unmute_title', { name: member.displayname }) as string,
+        text: this.$t('context.confirm.unmute_text', { name: member.displayname }) as string,
         icon: 'warning',
         showCancelButton: true,
-        confirmButtonText: this.$t('context.confirm.button_yes'),
-        cancelButtonText: this.$t('context.confirm.button_cancel'),
+        confirmButtonText: this.$t('context.confirm.button_yes') as string,
+        cancelButtonText: this.$t('context.confirm.button_cancel') as string,
       }).then(({ value }) => {
         if (value) {
           this.$accessor.user.unmute(member)

--- a/client/src/components/side.vue
+++ b/client/src/components/side.vue
@@ -4,11 +4,11 @@
       <ul>
         <li :class="{ active: tab === 'chat' }" @click.stop.prevent="change('chat')">
           <i class="fas fa-comment-alt" />
-          <span>{{ $t('chat') }}</span>
+          <span>{{ $t('side.chat') }}</span>
         </li>
         <li :class="{ active: tab === 'settings' }" @click.stop.prevent="change('settings')">
           <i class="fas fa-sliders-h" />
-          <span>{{ $t('settings') }}</span>
+          <span>{{ $t('side.settings') }}</span>
         </li>
       </ul>
     </div>

--- a/client/src/locale/en-us.ts
+++ b/client/src/locale/en-us.ts
@@ -5,6 +5,7 @@ export const unsupported = 'this browser does not support webrtc'
 export const admin_loggedin = 'You are logged in as an admin'
 export const you = 'You'
 export const ok = 'ok'
+export const send_a_message = 'Send a message'
 export const connected = 'connected'
 export const disconnected = 'disconnected'
 

--- a/client/src/locale/en-us.ts
+++ b/client/src/locale/en-us.ts
@@ -1,13 +1,13 @@
-export const chat = 'Chat'
-export const settings = 'Settings'
 export const logout = 'logout'
 export const unsupported = 'this browser does not support webrtc'
 export const admin_loggedin = 'You are logged in as an admin'
 export const you = 'You'
-export const ok = 'ok'
 export const send_a_message = 'Send a message'
-export const connected = 'connected'
-export const disconnected = 'disconnected'
+
+export const side = {
+  chat: 'Chat',
+  settings: 'Settings',
+}
 
 export const connect = {
   title: 'Please Login',
@@ -63,11 +63,15 @@ export const setting = {
 }
 
 export const connection = {
-  success: 'Successfully connected',
+  logged_out: 'You have been logged out!',
+  connected: 'Successfully connected',
+  disconnected: 'You have been disconnected',
+  button_confirm: 'Ok',
 }
 
 export const notifications = {
-  logged_out: '{name} logged out!',
+  connected: '{name} connected',
+  disconnected: '{name} disconnected',
   controls_taken: '{name} took the controls',
   controls_taken_force: 'force took the controls',
   controls_taken_steal: 'took the controls from {name}',

--- a/client/src/locale/en-us.ts
+++ b/client/src/locale/en-us.ts
@@ -25,6 +25,18 @@ export const context = {
   give: 'Give Controls',
   kick: 'Kick',
   ban: 'Ban IP',
+  confirm: {
+    kick_title: 'Kick {name}?',
+    kick_text: 'Are you sure you want to kick {name}?',
+    ban_title: 'Ban {name}?',
+    ban_text: 'Are you sure you want to ban {name}? You will need to restart the server to undo this.',
+    mute_title: 'Mute {name}?',
+    mute_text: 'Are you sure you want to mute {name}?',
+    unmute_title: 'Unmute {name}?',
+    unmute_text: 'Are you sure you want to unmute {name}?',
+    button_yes: 'Yes',
+    button_cancel: 'Cancel',
+  }
 }
 
 export const controls = {

--- a/client/src/locale/en-us.ts
+++ b/client/src/locale/en-us.ts
@@ -37,7 +37,7 @@ export const context = {
     unmute_text: 'Are you sure you want to unmute {name}?',
     button_yes: 'Yes',
     button_cancel: 'Cancel',
-  }
+  },
 }
 
 export const controls = {

--- a/client/src/neko/index.ts
+++ b/client/src/neko/index.ts
@@ -54,7 +54,7 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
     this.disconnect()
     this.cleanup()
     this.$vue.$swal({
-      title: this.$vue.$t('connection.logged_out', { name: this.$vue.$t('you') }),
+      title: this.$vue.$t('connection.logged_out'),
       icon: 'info',
       confirmButtonText: this.$vue.$t('connection.button_confirm') as string,
     })

--- a/client/src/neko/index.ts
+++ b/client/src/neko/index.ts
@@ -54,9 +54,9 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
     this.disconnect()
     this.cleanup()
     this.$vue.$swal({
-      title: this.$vue.$t('notifications.logged_out', { name: this.$vue.$t('you') }),
+      title: this.$vue.$t('connection.logged_out', { name: this.$vue.$t('you') }),
       icon: 'info',
-      confirmButtonText: this.$vue.$t('ok') as string,
+      confirmButtonText: this.$vue.$t('connection.button_confirm') as string,
     })
   }
 
@@ -75,7 +75,7 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
     this.$vue.$notify({
       group: 'neko',
       type: 'success',
-      title: this.$vue.$t('connection.success') as string,
+      title: this.$vue.$t('connection.connected') as string,
       duration: 5000,
       speed: 1000,
     })
@@ -86,7 +86,7 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
     this.$vue.$notify({
       group: 'neko',
       type: 'error',
-      title: this.$vue.$t('disconnected') as string,
+      title: this.$vue.$t('connection.disconnected') as string,
       text: reason ? reason.message : undefined,
       duration: 5000,
       speed: 1000,
@@ -111,10 +111,10 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
   protected [EVENT.SYSTEM.DISCONNECT]({ message }: DisconnectPayload) {
     this.onDisconnected(new Error(message))
     this.$vue.$swal({
-      title: this.$vue.$t('disconnected'),
+      title: this.$vue.$t('connection.disconnected'),
       text: message,
       icon: 'error',
-      confirmButtonText: this.$vue.$t('ok') as string,
+      confirmButtonText: this.$vue.$t('connection.button_confirm') as string,
     })
   }
 
@@ -125,7 +125,7 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
     this.$accessor.user.setMembers(members)
     this.$accessor.chat.newMessage({
       id: this.id,
-      content: this.$vue.$t('connected') as string,
+      content: this.$vue.$t('notifications.connected', { name: '' }) as string,
       type: 'event',
       created: new Date(),
     })
@@ -137,7 +137,7 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
     if (member.id !== this.id) {
       this.$accessor.chat.newMessage({
         id: member.id,
-        content: this.$vue.$t('connected') as string,
+        content: this.$vue.$t('notifications.connected', { name: '' }) as string,
         type: 'event',
         created: new Date(),
       })
@@ -152,7 +152,7 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
 
     this.$accessor.chat.newMessage({
       id: member.id,
-      content: this.$vue.$t('disconnected') as string,
+      content: this.$vue.$t('notifications.disconnected', { name: '' }) as string,
       type: 'event',
       created: new Date(),
     })

--- a/client/src/neko/index.ts
+++ b/client/src/neko/index.ts
@@ -54,7 +54,7 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
     this.disconnect()
     this.cleanup()
     this.$vue.$swal({
-      title: this.$vue.$t('notifications.logged_out', { name: 'You' }),
+      title: this.$vue.$t('notifications.logged_out', { name: this.$vue.$t('you') }),
       icon: 'info',
       confirmButtonText: this.$vue.$t('ok') as string,
     })
@@ -207,7 +207,7 @@ export class NekoClient extends BaseClient implements EventEmitter<NekoEvents> {
 
     this.$accessor.chat.newMessage({
       id: member.id,
-      content: this.$vue.$t('notifications.controls_released') as string,
+      content: this.$vue.$t('notifications.controls_released', { name: '' }) as string,
       type: 'event',
       created: new Date(),
     })


### PR DESCRIPTION
* Added `$swal` dialogs in `client/src/components/context.vue` to locale.
* Added `send_a_message` to locales.
* `chat` and `settings` grouped.
* `connection` group improved, so no dangling `connected` and `disconnected` are left behind.

I am planning to add Slovak and German translation, so I had to separate some phrases. Biggest problem are causing me notifications, where is starts with name or `You`, but not in all languages works it like in english. I have to change that in the future too.