### PR TITLE
Fix _+: keys in Firefox

### DIFF
--- a/client/src/components/video.vue
+++ b/client/src/components/video.vue
@@ -466,15 +466,15 @@
     // frick you firefox
     getCode(e: KeyboardEvent): number {
       let key = e.keyCode
-      if (key === 59 && e.key === ';') {
+      if (key === 59 && (e.key === ';' || e.key === ':')) {
         key = 186
       }
 
-      if (key === 61 && e.key === '=') {
+      if (key === 61 && (e.key === '=' || e.key === '+')) {
         key = 187
       }
 
-      if (key === 173 && e.key === '-') {
+      if (key === 173 && (e.key === '-' || e.key === '_')) {
         key = 189
       }
 


### PR DESCRIPTION
19466b5 fixes the keys without shift; this fixes them with shift.

Related: https://github.com/nurdism/neko/commit/19466b5625b6e6c2796faa7eeac0e3be1797f7f5
Context: https://github.com/nurdism/neko/issues/51#issuecomment-609877197