### PR TITLE
components/video.vue: fix keyup-on-blur code

### DIFF
--- a/client/src/components/video.vue
+++ b/client/src/components/video.vue
@@ -161,7 +161,7 @@
     private observer = new ResizeObserver(this.onResise.bind(this))
     private focused = false
     private fullscreen = false
-    private activeKeys: any = {}
+    private activeKeys: Set<number> = new Set()
 
     get admin() {
       return this.$accessor.user.admin
@@ -409,10 +409,9 @@
         return
       }
 
-      let keys = Object.keys(this.activeKeys)
-      for(let key of keys) {
+      for (let key of this.activeKeys) {
         this.$client.sendData('keyup', { key })
-        delete this.activeKeys[key]
+        this.activeKeys.delete(key)
       }
     }
 
@@ -503,7 +502,7 @@
 
       let key = this.getCode(e)
       this.$client.sendData('keydown', { key })
-      this.activeKeys[key] = true
+      this.activeKeys.add(key)
     }
 
     onKeyUp(e: KeyboardEvent) {
@@ -513,7 +512,7 @@
 
       let key = this.getCode(e)
       this.$client.sendData('keyup', { key })
-      delete this.activeKeys[key]
+      this.activeKeys.delete(key)
     }
 
     onResise() {


### PR DESCRIPTION
the code authored in 52ee7372765e272aad7cb52b9dceecf9d0145f55 (probably) worked in the browser due to string to numeric type autoconversion but didn't typecheck during container build.

namely, Object.keys(this.activeKeys) will always return a `string[]`; however, we need keys to be `number`s for the sendData() call to typecheck.

this replaces the untyped object holding active keys with a `Set<number>`, which is closer to intent anyway

fixes #78 