### PR TITLE
screen parsing fixed

### DIFF
--- a/server/internal/types/config/remote.go
+++ b/server/internal/types/config/remote.go
@@ -124,8 +124,8 @@ func (s *Remote) Set() {
 
 	if len(res) > 0 {
 		width, err1 := strconv.ParseInt(res[1], 10, 64)
-		height, err2 := strconv.ParseInt(res[1], 10, 64)
-		rate, err3 := strconv.ParseInt(res[1], 10, 64)
+		height, err2 := strconv.ParseInt(res[2], 10, 64)
+		rate, err3 := strconv.ParseInt(res[3], 10, 64)
 
 		if err1 == nil && err2 == nil && err3 == nil {
 			s.ScreenWidth = int(width)


### PR DESCRIPTION
Would result to invalid screen option, since it would parse `width` three times instead of other parameters.

```
WRN invalid screen option 1280x1280@1280 module=remote,
```