### PR TITLE
BUG: XKeysymToKeycode returns zero

### DIFF
--- a/server/internal/xorg/xorg.c
+++ b/server/internal/xorg/xorg.c
@@ -97,8 +97,11 @@ void XButton(unsigned int button, int down) {
 void XKey(unsigned long key, int down) {
   Display *display = getXDisplay();
   KeyCode code = XKeysymToKeycode(display, key);
-  XTestFakeKeyEvent(display, code, down, CurrentTime);
-  XSync(display, 0);
+
+  if (code != 0) {
+    XTestFakeKeyEvent(display, code, down, CurrentTime);
+    XSync(display, 0);
+  }
 }
 
 void XClipboardSet(char *src) {


### PR DESCRIPTION
 Having Num Lock turned off and pressing 5 on Num Pad crashes Neko.

`XKeysymToKeycode` function returns `0x00` for KeySym `65291`.

![image](https://user-images.githubusercontent.com/7534274/84567772-2ade0f00-ad7b-11ea-9fd8-0ce663f3e17a.png)
