### PR TITLE
Lower minimum scroll speed even further

### DIFF
--- a/client/src/components/settings.vue
+++ b/client/src/components/settings.vue
@@ -4,7 +4,7 @@
       <li>
         <span>{{ $t('setting.scroll') }}</span>
         <label class="slider">
-          <input type="range" min="5" max="100" v-model="scroll" />
+          <input type="range" min="1" max="100" v-model="scroll" />
         </label>
       </li>
       <li>


### PR DESCRIPTION
Current slowest scroll speed is still quite fast.
This changes the value from 5 down to 1, which brings a very nice change in speed with it.