### PR TITLE
Keyboard modifier state synchronization

### DIFF
--- a/client/src/components/video.vue
+++ b/client/src/components/video.vue
@@ -480,16 +480,33 @@
       if (!this.hosting || this.locked) {
         return
       }
+
       this.onMousePos(e)
     }
 
     onMouseEnter(e: MouseEvent) {
+      if(this.hosting) {
+        this.$accessor.remote.syncKeyboardModifierState({
+          capsLock: e.getModifierState("CapsLock"),
+          numLock: e.getModifierState("NumLock"),
+          scrollLock: e.getModifierState("ScrollLock"),
+        })
+      }
+
       this._overlay.focus()
       this.onFocus()
       this.focused = true
     }
 
     onMouseLeave(e: MouseEvent) {
+      if(this.hosting) {
+        this.$accessor.remote.setKeyboardModifierState({
+          capsLock: e.getModifierState("CapsLock"),
+          numLock: e.getModifierState("NumLock"),
+          scrollLock: e.getModifierState("ScrollLock"),
+        })
+      }
+
       this.focused = false
     }
 

--- a/client/src/neko/events.ts
+++ b/client/src/neko/events.ts
@@ -27,7 +27,7 @@ export const EVENT = {
     REQUESTING: 'control/requesting',
     CLIPBOARD: 'control/clipboard',
     GIVE: 'control/give',
-    KEYBOARD: 'control/keyboard'
+    KEYBOARD: 'control/keyboard',
   },
   CHAT: {
     MESSAGE: 'chat/message',

--- a/client/src/neko/messages.ts
+++ b/client/src/neko/messages.ts
@@ -122,7 +122,10 @@ export interface ControlClipboardPayload {
 }
 
 export interface ControlKeyboardPayload {
-  layout: string
+  layout?: string
+  capsLock?: boolean
+  numLock?: boolean
+  scrollLock?: boolean
 }
 
 /*

--- a/client/src/store/remote.ts
+++ b/client/src/store/remote.ts
@@ -3,12 +3,18 @@ import { Member } from '~/neko/types'
 import { EVENT } from '~/neko/events'
 import { accessor } from '~/store'
 
+const keyboardModifierState =
+  (capsLock: boolean, numLock: boolean, scrollLock: boolean) =>
+    Number(capsLock) + 2*Number(numLock) + 4*Number(scrollLock)
+
 export const namespaced = true
 
 export const state = () => ({
   id: '',
   clipboard: '',
   locked: false,
+
+  keyboardModifierState: -1,
 })
 
 export const getters = getterTree(state, {
@@ -36,6 +42,10 @@ export const mutations = mutationTree(state, {
     state.clipboard = clipboard
   },
 
+  setKeyboardModifierState(state, { capsLock, numLock, scrollLock }) {
+    state.keyboardModifierState = keyboardModifierState(capsLock, numLock, scrollLock)
+  },
+
   setLocked(state, locked: boolean) {
     state.locked = locked
   },
@@ -44,6 +54,7 @@ export const mutations = mutationTree(state, {
     state.id = ''
     state.clipboard = ''
     state.locked = false
+    state.keyboardModifierState = -1
   },
 })
 
@@ -140,6 +151,15 @@ export const actions = actionTree(
       }
 
       $client.sendMessage(EVENT.CONTROL.KEYBOARD, { layout: accessor.settings.keyboard_layout })
+    },
+
+    syncKeyboardModifierState({ state, getters }, { capsLock, numLock, scrollLock }) {
+      if (state.keyboardModifierState === keyboardModifierState(capsLock, numLock, scrollLock)) {
+        return ;
+      }
+
+      accessor.remote.setKeyboardModifierState({ capsLock, numLock, scrollLock })
+      $client.sendMessage(EVENT.CONTROL.KEYBOARD, { capsLock, numLock, scrollLock })
     }
   },
 )

--- a/server/internal/remote/manager.go
+++ b/server/internal/remote/manager.go
@@ -32,12 +32,6 @@ func New(config *config.Remote) *RemoteManager {
 		emmiter:   events.New(),
 		config:    config,
 		streaming: false,
-
-		keyboardModifierState: {
-			CapsLock: false,
-			NumLock: false,
-			ScrollLock: false,
-		}
 	}
 }
 
@@ -229,6 +223,6 @@ func (manager *RemoteManager) SetKeyboard(layout string) {
 	xorg.SetKeyboard(layout)
 }
 
-func (manager *RemoteManager) SetKeyboard(NumLock int, CapsLock int, ScrollLock int) {
+func (manager *RemoteManager) SetKeyboardModifiers(NumLock int, CapsLock int, ScrollLock int) {
 	xorg.SetKeyboardModifiers(NumLock, CapsLock, ScrollLock)
 }

--- a/server/internal/remote/manager.go
+++ b/server/internal/remote/manager.go
@@ -32,6 +32,12 @@ func New(config *config.Remote) *RemoteManager {
 		emmiter:   events.New(),
 		config:    config,
 		streaming: false,
+
+		keyboardModifierState: {
+			CapsLock: false,
+			NumLock: false,
+			ScrollLock: false,
+		}
 	}
 }
 
@@ -221,4 +227,8 @@ func (manager *RemoteManager) GetScreenSize() *types.ScreenSize {
 
 func (manager *RemoteManager) SetKeyboard(layout string) {
 	xorg.SetKeyboard(layout)
+}
+
+func (manager *RemoteManager) SetKeyboard(NumLock int, CapsLock int, ScrollLock int) {
+	xorg.SetKeyboardModifiers(NumLock, CapsLock, ScrollLock)
 }

--- a/server/internal/types/message/messages.go
+++ b/server/internal/types/message/messages.go
@@ -47,8 +47,11 @@ type Clipboard struct {
 }
 
 type Keyboard struct {
-	Event  string `json:"event"`
-	Layout string `json:"layout"`
+	Event      string  `json:"event"`
+	Layout     *string `json:"layout,omitempty"`
+	CapsLock   *bool   `json:"capsLock,omitempty"`
+	NumLock    *bool   `json:"numLock,omitempty"`
+	ScrollLock *bool   `json:"scrollLock,omitempty"`
 }
 
 type Control struct {

--- a/server/internal/types/remote.go
+++ b/server/internal/types/remote.go
@@ -23,4 +23,5 @@ type RemoteManager interface {
 	WriteClipboard(data string)
 	ResetKeys()
 	SetKeyboard(layout string)
+	SetKeyboard(NumLock int, CapsLock int, ScrollLock int)
 }

--- a/server/internal/types/remote.go
+++ b/server/internal/types/remote.go
@@ -23,5 +23,5 @@ type RemoteManager interface {
 	WriteClipboard(data string)
 	ResetKeys()
 	SetKeyboard(layout string)
-	SetKeyboard(NumLock int, CapsLock int, ScrollLock int)
+	SetKeyboardModifiers(NumLock int, CapsLock int, ScrollLock int)
 }

--- a/server/internal/websocket/control.go
+++ b/server/internal/websocket/control.go
@@ -116,6 +116,11 @@ func (h *MessageHandler) controlClipboard(id string, session types.Session, payl
 	return nil
 }
 
+// TODO: Refactor
+var CapsLock = false
+var NumLock = false
+var ScrollLock = false
+
 func (h *MessageHandler) controlKeyboard(id string, session types.Session, payload *message.Keyboard) error {
 	// check if session is host
 	if !h.sessions.IsHost(id) {
@@ -123,6 +128,34 @@ func (h *MessageHandler) controlKeyboard(id string, session types.Session, paylo
 		return nil
 	}
 
-	h.remote.SetKeyboard(payload.Layout)
+	// change layout
+	if payload.Layout != nil {
+		h.remote.SetKeyboard(*payload.Layout)
+	}
+
+	// set caps lock
+	if payload.CapsLock != nil && *payload.CapsLock != CapsLock {
+		h.remote.KeyDown(0xffe5)
+		h.remote.KeyUp(0xffe5)
+
+		CapsLock = *payload.CapsLock
+	}
+
+	// set num lock
+	if payload.NumLock != nil && *payload.NumLock != NumLock {
+		h.remote.KeyDown(0xff7f)
+		h.remote.KeyUp(0xff7f)
+
+		NumLock = *payload.NumLock
+	}
+
+	// set scroll lock
+	if payload.ScrollLock != nil && *payload.ScrollLock != ScrollLock {
+		h.remote.KeyDown(0xff14)
+		h.remote.KeyUp(0xff14)
+
+		ScrollLock = *payload.ScrollLock
+	}
+
 	return nil
 }

--- a/server/internal/websocket/control.go
+++ b/server/internal/websocket/control.go
@@ -116,11 +116,6 @@ func (h *MessageHandler) controlClipboard(id string, session types.Session, payl
 	return nil
 }
 
-// TODO: Refactor
-var CapsLock = false
-var NumLock = false
-var ScrollLock = false
-
 func (h *MessageHandler) controlKeyboard(id string, session types.Session, payload *message.Keyboard) error {
 	// check if session is host
 	if !h.sessions.IsHost(id) {
@@ -134,28 +129,29 @@ func (h *MessageHandler) controlKeyboard(id string, session types.Session, paylo
 	}
 
 	// set caps lock
-	if payload.CapsLock != nil && *payload.CapsLock != CapsLock {
-		h.remote.KeyDown(0xffe5)
-		h.remote.KeyUp(0xffe5)
-
-		CapsLock = *payload.CapsLock
+	var CapsLock = 0
+	if payload.CapsLock == nil {
+		CapsLock = -1
+	} else if *payload.CapsLock {
+		CapsLock = 1
 	}
 
 	// set num lock
-	if payload.NumLock != nil && *payload.NumLock != NumLock {
-		h.remote.KeyDown(0xff7f)
-		h.remote.KeyUp(0xff7f)
-
-		NumLock = *payload.NumLock
+	var NumLock = 0
+	if payload.NumLock == nil {
+		NumLock = -1
+	} else if *payload.NumLock {
+		NumLock = 1
 	}
 
 	// set scroll lock
-	if payload.ScrollLock != nil && *payload.ScrollLock != ScrollLock {
-		h.remote.KeyDown(0xff14)
-		h.remote.KeyUp(0xff14)
-
-		ScrollLock = *payload.ScrollLock
+	var ScrollLock = 0
+	if payload.ScrollLock == nil {
+		ScrollLock = -1
+	} else if *payload.ScrollLock {
+		ScrollLock = 1
 	}
 
+	h.remote.SetKeyboardModifiers(CapsLock, NumLock, ScrollLock)
 	return nil
 }

--- a/server/internal/websocket/control.go
+++ b/server/internal/websocket/control.go
@@ -152,6 +152,12 @@ func (h *MessageHandler) controlKeyboard(id string, session types.Session, paylo
 		ScrollLock = 1
 	}
 
+	h.logger.Debug().
+		Int("NumLock", NumLock).
+		Int("CapsLock", CapsLock).
+		Int("ScrollLock", ScrollLock).
+		Msg("setting keyboard modifiers")
+
 	h.remote.SetKeyboardModifiers(NumLock, CapsLock, ScrollLock)
 	return nil
 }

--- a/server/internal/websocket/control.go
+++ b/server/internal/websocket/control.go
@@ -128,20 +128,20 @@ func (h *MessageHandler) controlKeyboard(id string, session types.Session, paylo
 		h.remote.SetKeyboard(*payload.Layout)
 	}
 
-	// set caps lock
-	var CapsLock = 0
-	if payload.CapsLock == nil {
-		CapsLock = -1
-	} else if *payload.CapsLock {
-		CapsLock = 1
-	}
-
 	// set num lock
 	var NumLock = 0
 	if payload.NumLock == nil {
 		NumLock = -1
 	} else if *payload.NumLock {
 		NumLock = 1
+	}
+
+	// set caps lock
+	var CapsLock = 0
+	if payload.CapsLock == nil {
+		CapsLock = -1
+	} else if *payload.CapsLock {
+		CapsLock = 1
 	}
 
 	// set scroll lock
@@ -152,6 +152,6 @@ func (h *MessageHandler) controlKeyboard(id string, session types.Session, paylo
 		ScrollLock = 1
 	}
 
-	h.remote.SetKeyboardModifiers(CapsLock, NumLock, ScrollLock)
+	h.remote.SetKeyboardModifiers(NumLock, CapsLock, ScrollLock)
 	return nil
 }

--- a/server/internal/xorg/xorg.c
+++ b/server/internal/xorg/xorg.c
@@ -172,3 +172,35 @@ void SetKeyboard(char *layout) {
   strncat(cmd, layout, 2);
   system(cmd);
 }
+
+void SetKeyboardModifiers(int num_lock, int caps_lock, int scroll_lock) {
+  // TOOD: refactor, use native API.
+  // https://stackoverflow.com/questions/8427817/how-to-get-a-num-lock-state-using-c-c/8429021
+  Display *display = getXDisplay();
+  XKeyboardState x;
+  XGetKeyboardControl(display, &x);
+
+  // set caps lock
+  //printf("CapsLock is %s\n", (x.led_mask & 1) ? "On" : "Off");
+  if(caps_lock != -1 && x.led_mask & 1 != caps_lock) {
+    XKey(0xffe5, 1);
+    XKey(0xffe5, 0);
+  }
+
+  // set num lock
+  //printf("NumLock is %s\n", (x.led_mask & 2) ? "On" : "Off");
+  if(num_lock != -1 && x.led_mask & 2 != num_lock) {
+    XKey(0xff7f, 1);
+    XKey(0xff7f, 0);
+  }
+
+  /* NOT SUPPORTED
+  // set scroll lock
+  //printf("ScrollLock is %s\n", (x.led_mask & 4) ? "On" : "Off");
+  if(scroll_lock != -1 && x.led_mask & 4 != scroll_lock) {
+    XKey(0xff14, 1);
+    XKey(0xff14, 0);
+  }
+  */
+}
+

--- a/server/internal/xorg/xorg.c
+++ b/server/internal/xorg/xorg.c
@@ -174,33 +174,34 @@ void SetKeyboard(char *layout) {
 }
 
 void SetKeyboardModifiers(int num_lock, int caps_lock, int scroll_lock) {
-  // TOOD: refactor, use native API.
-  // https://stackoverflow.com/questions/8427817/how-to-get-a-num-lock-state-using-c-c/8429021
   Display *display = getXDisplay();
-  XKeyboardState x;
-  XGetKeyboardControl(display, &x);
-
-  // set caps lock
-  //printf("CapsLock is %s\n", (x.led_mask & 1) ? "On" : "Off");
-  if(caps_lock != -1 && x.led_mask & 1 != caps_lock) {
-    XKey(0xffe5, 1);
-    XKey(0xffe5, 0);
-  }
+  Bool state;
+  Atom atom;
 
   // set num lock
-  //printf("NumLock is %s\n", (x.led_mask & 2) ? "On" : "Off");
-  if(num_lock != -1 && x.led_mask & 2 != num_lock) {
-    XKey(0xff7f, 1);
-    XKey(0xff7f, 0);
+  atom = XInternAtom(display, "Num Lock", 0);
+  XkbGetNamedIndicator(display, atom, NULL, &state, NULL, NULL);
+  //printf("Num Lock is %s\n", state ? "on" : "off");
+  if(num_lock != -1 && state != num_lock) {
+    XKey(XK_Num_Lock, 1);
+    XKey(XK_Num_Lock, 0);
   }
 
-  /* NOT SUPPORTED
+  // set caps lock
+  atom = XInternAtom(display, "Caps Lock", 0);
+  XkbGetNamedIndicator(display, atom, NULL, &state, NULL, NULL);
+  //printf("Caps Lock is %s\n", state ? "on" : "off");
+  if(caps_lock != -1 && state != caps_lock) {
+    XKey(XK_Caps_Lock, 1);
+    XKey(XK_Caps_Lock, 0);
+  }
+
   // set scroll lock
-  //printf("ScrollLock is %s\n", (x.led_mask & 4) ? "On" : "Off");
-  if(scroll_lock != -1 && x.led_mask & 4 != scroll_lock) {
-    XKey(0xff14, 1);
-    XKey(0xff14, 0);
+  atom = XInternAtom(display, "Scroll Lock", 0);
+  XkbGetNamedIndicator(display, atom, NULL, &state, NULL, NULL);
+  //printf("Scroll Lock is %s\n", state ? "on" : "off");
+  if(scroll_lock != -1 && state != scroll_lock) {
+    XKey(XK_Scroll_Lock, 1);
+    XKey(XK_Scroll_Lock, 0);
   }
-  */
 }
-

--- a/server/internal/xorg/xorg.c
+++ b/server/internal/xorg/xorg.c
@@ -175,33 +175,21 @@ void SetKeyboard(char *layout) {
 
 void SetKeyboardModifiers(int num_lock, int caps_lock, int scroll_lock) {
   Display *display = getXDisplay();
-  Bool state;
-  Atom atom;
 
-  // set num lock
-  atom = XInternAtom(display, "Num Lock", 0);
-  XkbGetNamedIndicator(display, atom, NULL, &state, NULL, NULL);
-  //printf("Num Lock is %s\n", state ? "on" : "off");
-  if(num_lock != -1 && state != num_lock) {
-    XKey(XK_Num_Lock, 1);
-    XKey(XK_Num_Lock, 0);
+  if (num_lock != -1) {
+    XkbLockModifiers(display, XkbUseCoreKbd, 16, num_lock * 16);
   }
 
-  // set caps lock
-  atom = XInternAtom(display, "Caps Lock", 0);
-  XkbGetNamedIndicator(display, atom, NULL, &state, NULL, NULL);
-  //printf("Caps Lock is %s\n", state ? "on" : "off");
-  if(caps_lock != -1 && state != caps_lock) {
-    XKey(XK_Caps_Lock, 1);
-    XKey(XK_Caps_Lock, 0);
+  if (caps_lock != -1) {
+    XkbLockModifiers(display, XkbUseCoreKbd, 2, caps_lock * 2);
   }
 
-  // set scroll lock
-  atom = XInternAtom(display, "Scroll Lock", 0);
-  XkbGetNamedIndicator(display, atom, NULL, &state, NULL, NULL);
-  //printf("Scroll Lock is %s\n", state ? "on" : "off");
-  if(scroll_lock != -1 && state != scroll_lock) {
-    XKey(XK_Scroll_Lock, 1);
-    XKey(XK_Scroll_Lock, 0);
+  if (scroll_lock != -1) {
+    XKeyboardControl values;
+    values.led_mode = scroll_lock ? LedModeOn : LedModeOff;
+    values.led = 3;
+    XChangeKeyboardControl(display, KBLedMode, &values);
   }
+
+  XFlush(display);
 }

--- a/server/internal/xorg/xorg.go
+++ b/server/internal/xorg/xorg.go
@@ -225,6 +225,13 @@ func SetKeyboard(layout string) {
 	C.SetKeyboard(layoutUnsafe)
 }
 
+func SetKeyboardModifiers(num_lock int, caps_lock int, scroll_lock int) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	C.SetKeyboardModifiers(C.int(num_lock), C.int(caps_lock), C.int(scroll_lock))
+}
+
 //export goCreateScreenSize
 func goCreateScreenSize(index C.int, width C.int, height C.int, mwidth C.int, mheight C.int) {
 	ScreenConfigurations[int(index)] = types.ScreenConfiguration{

--- a/server/internal/xorg/xorg.h
+++ b/server/internal/xorg/xorg.h
@@ -4,6 +4,8 @@
   #define XDISPLAY_H
 
   #include <X11/Xlib.h>
+  #include <X11/XKBlib.h>
+  #include <X11/keysym.h>
   #include <X11/extensions/Xrandr.h>
   #include <X11/extensions/XTest.h>
   #include <libclipboard.h>

--- a/server/internal/xorg/xorg.h
+++ b/server/internal/xorg/xorg.h
@@ -5,7 +5,6 @@
 
   #include <X11/Xlib.h>
   #include <X11/XKBlib.h>
-  #include <X11/keysym.h>
   #include <X11/extensions/Xrandr.h>
   #include <X11/extensions/XTest.h>
   #include <libclipboard.h>

--- a/server/internal/xorg/xorg.h
+++ b/server/internal/xorg/xorg.h
@@ -40,5 +40,6 @@
   void XDisplaySet(char *input);
 
   void SetKeyboard(char *layout);
+  void SetKeyboardModifiers(int num_lock, int caps_lock, int scroll_lock);
 #endif
 


### PR DESCRIPTION
Synchronize `CapsLock`, `NumLock` and `ScrollLock` with client.

Only from Mouse and Keyobard events can we get users state. That's why state is synchronized one user first enters canvas with mosue.

Known isues:
* `ScrollLock` is not working at all when pressing in Linux canvas. Bus synchronization works. Maybe is not used and could be just ignores.
* Sometimes ist works in reverse. Hard to tell when, just... sometimes it bugs. I couldn't find what causes this bug. Needs propper testing.