### PR TITLE
Update xorg.conf to support 1920x1080 @ 60 Hz

### DIFF
--- a/.docker/files/base/xorg.conf
+++ b/.docker/files/base/xorg.conf
@@ -56,6 +56,8 @@ Section "Monitor"
   # 800x600 @ 60.00 Hz (GTF) hsync: 37.32 kHz; pclk: 38.22 MHz
   Modeline "800x600_60.00" 38.22 800 832 912 1024 600 601 604 622 -HSync +Vsync
   
+  # 1920x1080 @ 60.00 Hz (GTF) hsync: 67.08 kHz; pclk: 172.80 MHz
+  Modeline "1920x1080_60.00" 172.80 1920 2040 2248 2576 1080 1081 1084 1118 -HSync +Vsync
   # 1920x1080 @ 30.00 Hz (GTF) hsync: 32.97 kHz; pclk: 80.18 MHz
   Modeline "1920x1080_30.00" 80.18 1920 1984 2176 2432 1080 1081 1084 1099 -HSync +Vsync
   # 1152x648 @ 30.00 Hz (GTF) hsync: 19.80 kHz; pclk: 26.93 MHz


### PR DESCRIPTION
Neko should automatically recognize the new option of running 1080p at 60hz (at least in my testing) - and things seem to work as expected.

It seems this option was already technically supported by the "Display" modes on line 81 - it seems to have just been missing the Modeline configuration.

With that said, using this resolution will increase the necessary bandwidth and computing power required to run Neko - but users should at least have the ability to run at this resolution/refresh rate. 