### PR TITLE
New image source for avatars

### DIFF
--- a/client/src/components/chat.vue
+++ b/client/src/components/chat.vue
@@ -4,7 +4,7 @@
       <template v-for="(message, index) in history">
         <li :key="index" class="message" v-if="message.type === 'text'">
           <div class="author" @contextmenu.stop.prevent="onContext($event, { member: member(message.id) })">
-            <img :src="`https://ui-avatars.com/api/?name=${member(message.id).displayname}.png&size=40`" />
+            <img :src="`https://avatars.dicebear.com/4.5/api/gridy/${member(message.id).displayname}.svg`" />
           </div>
           <div class="content">
             <div class="content-head">

--- a/client/src/components/context.vue
+++ b/client/src/components/context.vue
@@ -3,7 +3,7 @@
     <template slot-scope="child" v-if="child.data">
       <li class="header">
         <div class="user">
-          <img :src="`https://ui-avatars.com/api/?name=${child.data.member.displayname}.png&size=25`" />
+          <img :src="`https://avatars.dicebear.com/4.5/api/gridy/${child.data.member.displayname}.svg`" />
           <strong>{{ child.data.member.displayname }}</strong>
         </div>
       </li>

--- a/client/src/components/members.vue
+++ b/client/src/components/members.vue
@@ -4,7 +4,7 @@
       <ul class="members-list">
         <li v-if="member">
           <div :class="[{ host: member.id === host }, 'self', 'member']">
-            <img :src="`https://ui-avatars.com/api/?name=${member.displayname}.png&size=50`" />
+            <img :src="`https://avatars.dicebear.com/4.5/api/gridy/${member.displayname}.svg`" />
           </div>
         </li>
         <template v-for="(member, index) in members">
@@ -15,7 +15,7 @@
           >
             <div :class="[{ host: member.id === host, admin: member.admin }, 'member']">
               <img
-                :src="`https://ui-avatars.com/api/?name=${member.displayname}.png&size=50`"
+                :src="`https://avatars.dicebear.com/4.5/api/gridy/${member.displayname}.svg`"
                 @contextmenu.stop.prevent="onContext($event, { member })"
               />
             </div>


### PR DESCRIPTION
Using the [DiceBear Avatars API](https://avatars.dicebear.com/) for avatar images, since adorable.io is dead

I'm using the grindy style because its unisex and its cute. Avatar examples:

![1](https://avatars.dicebear.com/4.5/api/gridy/dd.svg)
![1](https://avatars.dicebear.com/4.5/api/gridy/test2.svg)